### PR TITLE
NPM v9 compatibility

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,7 +11,7 @@ jobs:
       matrix:
         include:
           - { node-version: 14.x, lint: true, tests: true }
-          - { node-version: 15.x, lint: true, tests: true }
+          - { node-version: 15.x, lint: false, tests: true }
           - { node-version: 16.x, lint: true, tests: true }
           - { node-version: 17.x, lint: true, tests: true }
           - { node-version: 18.x, lint: true, tests: true }

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,7 +19,7 @@ jobs:
           - { node-version: 16.x, lint: true, tests: true }
           - { node-version: 17.x, lint: true, tests: true }
           - { node-version: 18.x, lint: true, tests: true }
-          - { node-version: 19.x, lint: true, tests: true }
+          - { node-version: 19.x, lint: false, tests: true }
 
     name: nodejs ${{ matrix.node-version }} (${{ matrix.lint && 'lint → ' || '' }}${{ matrix.tests && 'test → ' || '' }}build)
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -32,7 +32,10 @@ jobs:
           node-version: ${{ matrix.node-version }}
 
       - name: Update node-gyp
-        run: npm explore npm/node_modules/@npmcli/run-script -g -- npm_config_global=false npm install node-gyp@latest
+        run: npm explore npm -g -- ls node_modules/
+
+      - name: Update node-gyp debug
+        run: npm explore npm -g -- ls node_modules/*
 
       - name: Cache node modules
         id: cache-npm

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -32,7 +32,7 @@ jobs:
           node-version: ${{ matrix.node-version }}
 
       - name: Update node-gyp
-        run: npm install node-gyp@latest -g
+        run: npm explore npm/node_modules/@npmcli/run-script -g -- npm_config_global=false npm install node-gyp@latest
 
       - name: Cache node modules
         id: cache-npm

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,10 +10,6 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - { node-version: 10.x, lint: false, tests: false }
-          - { node-version: 11.x, lint: false, tests: false }
-          - { node-version: 12.x, lint: false, tests: false }
-          - { node-version: 13.x, lint: false, tests: false }
           - { node-version: 14.x, lint: true, tests: true }
           - { node-version: 15.x, lint: false, tests: true }
           - { node-version: 16.x, lint: true, tests: true }
@@ -30,9 +26,6 @@ jobs:
         uses: actions/setup-node@v3
         with:
           node-version: ${{ matrix.node-version }}
-
-      - name: Update node-gyp
-        run: npm install node-gyp@latest -g
 
       - name: Cache node modules
         id: cache-npm

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -31,11 +31,8 @@ jobs:
         with:
           node-version: ${{ matrix.node-version }}
 
-      - name: Update node-gyp
-        run: npm explore npm -g -- ls node_modules/
-
-      - name: Update node-gyp debug
-        run: npm explore npm -g -- ls node_modules/*
+      - name: Update npm
+        run: npm install --global npm
 
       - name: Cache node modules
         id: cache-npm
@@ -44,7 +41,7 @@ jobs:
           cache-name: cache-node-modules
         with:
           path: node_modules
-          key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/package-lock.json', '**/package.json') }}
+          key: ${{ runner.os }}-${{ env.cache-name }}-${{ hashFiles('**/package-lock.json', '**/package.json') }}
 
       - name: Cache eslint
         id: cache-eslint

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,7 +11,7 @@ jobs:
       matrix:
         include:
           - { node-version: 14.x, lint: true, tests: true }
-          - { node-version: 15.x, lint: false, tests: true }
+          - { node-version: 15.x, lint: true, tests: true }
           - { node-version: 16.x, lint: true, tests: true }
           - { node-version: 17.x, lint: true, tests: true }
           - { node-version: 18.x, lint: true, tests: true }

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -31,8 +31,8 @@ jobs:
         with:
           node-version: ${{ matrix.node-version }}
 
-      - name: Update npm
-        run: npm install --global npm
+      - name: Update node-gyp
+        run: npm install node-gyp@latest
 
       - name: Cache node modules
         id: cache-npm

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,7 +19,7 @@ jobs:
           - { node-version: 16.x, lint: true, tests: true }
           - { node-version: 17.x, lint: true, tests: true }
           - { node-version: 18.x, lint: true, tests: true }
-          - { node-version: 19.x, lint: false, tests: true }
+          - { node-version: 19.x, lint: true, tests: true }
 
     name: nodejs ${{ matrix.node-version }} (${{ matrix.lint && 'lint → ' || '' }}${{ matrix.tests && 'test → ' || '' }}build)
 
@@ -32,7 +32,7 @@ jobs:
           node-version: ${{ matrix.node-version }}
 
       - name: Update node-gyp
-        run: npm install node-gyp@latest
+        run: npm install node-gyp@latest -g
 
       - name: Cache node modules
         id: cache-npm

--- a/package.json
+++ b/package.json
@@ -20,11 +20,11 @@
         "homebridge-ble-thermobeacon-scan": "dist/bin/homebridge-ble-thermobeacon-scan.js"
     },
     "scripts": {
-        "lint": "ifNotCi() { test \"$CI\" && echo \"$2\" || echo \"$1\"; }; `npm bin`/tsc --noEmit && `npm bin`/prettier --ignore-path=.gitignore `ifNotCi --write \"--check --cache --cache-strategy content\"` '**/**.{ts,js,json}' && `npm bin`/eslint `ifNotCi --fix \"--cache --cache-strategy content\"` --ignore-path=.gitignore '**/**.{ts,js,json}'",
+        "lint": "ifNotCi() { test \"$CI\" && echo \"$2\" || echo \"$1\"; }; npx tsc --noEmit && npx prettier --ignore-path=.gitignore `ifNotCi --write \"--check --cache --cache-strategy content\"` '**/**.{ts,js,json}' && npx eslint `ifNotCi --fix \"--cache --cache-strategy content\"` --ignore-path=.gitignore '**/**.{ts,js,json}'",
         "start": "npm run build && npm run link && nodemon",
         "link": "npm install --no-save file:///$PWD/",
         "build": "rimraf ./dist .tsbuildinfo && tsc",
-        "test": "ifNotCi() { test \"$CI\" && echo \"$2\" || echo \"$1\"; }; `npm bin`/jest `ifNotCi --watchAll --collect-coverage`",
+        "test": "ifNotCi() { test \"$CI\" && echo \"$2\" || echo \"$1\"; }; npx jest `ifNotCi --watchAll --collect-coverage`",
         "prepublishOnly": "npm run lint && npm run build",
         "release": "release-it --only-version"
     },


### PR DESCRIPTION
`npm bin` no longer exists in npm version 9, so we use `npx` to run local commands instead. `npm exec` would work as well, but that was only introduced with npx version 7 and node 14 uses version 6. Duh!