### PR TITLE
Replace npx with a portable npm exec implementation

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,11 +20,12 @@
         "homebridge-ble-thermobeacon-scan": "dist/bin/homebridge-ble-thermobeacon-scan.js"
     },
     "scripts": {
-        "lint": "ifNotCi() { test \"$CI\" && echo \"$2\" || echo \"$1\"; }; npx tsc --noEmit && npx prettier --ignore-path=.gitignore `ifNotCi --write \"--check --cache --cache-strategy content\"` '**/**.{ts,js,json}' && npx eslint `ifNotCi --fix \"--cache --cache-strategy content\"` --ignore-path=.gitignore '**/**.{ts,js,json}'",
+        "_portable_exec": "npmPortableExec() { `npm root`/.bin/$@; }; npmPortableExec",
+        "lint": "ifNotCi() { test \"$CI\" && echo \"$2\" || echo \"$1\"; }; npm run _portable_exec -- tsc --noEmit && npm run _portable_exec -- prettier --ignore-path=.gitignore `ifNotCi --write \"--check --cache --cache-strategy content\"` '**/**.{ts,js,json}' && npm run _portable_exec -- eslint `ifNotCi --fix \"--cache --cache-strategy content\"` --ignore-path=.gitignore '**/**.{ts,js,json}'",
         "start": "npm run build && npm run link && nodemon",
         "link": "npm install --no-save file:///$PWD/",
         "build": "rimraf ./dist .tsbuildinfo && tsc",
-        "test": "ifNotCi() { test \"$CI\" && echo \"$2\" || echo \"$1\"; }; npx jest `ifNotCi --watchAll --collect-coverage`",
+        "test": "ifNotCi() { test \"$CI\" && echo \"$2\" || echo \"$1\"; }; npm run _portable_exec -- jest `ifNotCi --watchAll --collect-coverage`",
         "prepublishOnly": "npm run lint && npm run build",
         "release": "release-it --only-version"
     },


### PR DESCRIPTION
`npx` will also consider global installations potentially leading to build issues.