### PR TITLE
Use dynamic imports for noble

### DIFF
--- a/src/adapters/ble/noble.ts
+++ b/src/adapters/ble/noble.ts
@@ -14,8 +14,7 @@ export const nobleDiscoverPeripherals: BlePeripheralsDiscovery = (
     import('@abandonware/noble')
         .then((module) => {
             try {
-                const noble = newNoble(module)
-                startDiscovery(noble, handlers, sensorDataHandler, errorHandler)
+                startDiscovery(newNoble(module), handlers, sensorDataHandler, errorHandler)
             } catch (e) {
                 errorHandler(e as Error)
             }

--- a/src/adapters/ble/noble.ts
+++ b/src/adapters/ble/noble.ts
@@ -6,10 +6,6 @@ import { throttle } from '../../std'
 type Noble = typeof _noble
 type Peripheral = _noble.Peripheral
 
-function newNoble(module: { default: (new (args: Record<string, unknown>) => Noble) | Noble }): Noble {
-    return typeof module.default === 'function' ? new module.default({ extended: false }) : module.default
-}
-
 export const nobleDiscoverPeripherals: BlePeripheralsDiscovery = (
     handlers: ThermometerHandler[],
     sensorDataHandler: (sensorData: SensorData) => void,
@@ -25,6 +21,10 @@ export const nobleDiscoverPeripherals: BlePeripheralsDiscovery = (
             }
         })
         .catch((e) => errorHandler(e as Error))
+}
+
+function newNoble(module: { default: (new (args: Record<string, unknown>) => Noble) | Noble }): Noble {
+    return typeof module.default === 'function' ? new module.default({ extended: false }) : module.default
 }
 
 function startDiscovery(

--- a/src/adapters/ble/noble.ts
+++ b/src/adapters/ble/noble.ts
@@ -1,44 +1,55 @@
-import Noble, { type Peripheral } from '@abandonware/noble'
+import type Noble from '@abandonware/noble'
 import type { SensorData, ThermometerHandler } from '../../thermometer'
 import type { BlePeripheralsDiscovery } from './api'
 import { throttle } from '../../std'
+
+function newNoble(module: {
+    default: (new (args: Record<string, unknown>) => typeof Noble) | typeof Noble
+}): typeof Noble {
+    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+    // @ts-ignore Type information are foobar’ed
+    const noble = typeof module.default === 'function' ? new module.default({ extended: false }) : module.default
+    return noble
+}
 
 export const nobleDiscoverPeripherals: BlePeripheralsDiscovery = (
     handlers: ThermometerHandler[],
     sensorDataHandler: (sensorData: SensorData) => void,
     errorHandler: (error: Error) => void,
 ) => {
-    try {
-        // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-        // @ts-ignore Type information are foobar’ed
-        const noble = (typeof Noble === 'function' ? new Noble({ extended: false }) : Noble) as typeof Noble
+    import('@abandonware/noble')
+        .then((module) => {
+            try {
+                const noble = newNoble(module)
 
-        noble.on('stateChange', (state: string) => {
-            if (state !== 'poweredOn') {
-                return
+                noble.on('stateChange', (state: string) => {
+                    if (state !== 'poweredOn') {
+                        return
+                    }
+
+                    noble.startScanning([], true)
+                })
+
+                noble.on(
+                    'discover',
+                    throttle(
+                        3_000,
+                        handleDiscover.bind(null, handlers, sensorDataHandler, errorHandler),
+                        (peripheral) => peripheral.uuid,
+                    ),
+                )
+            } catch (e) {
+                errorHandler(e as Error)
             }
-
-            noble.startScanning([], true)
         })
-
-        noble.on(
-            'discover',
-            throttle(
-                3_000,
-                handleDiscover.bind(null, handlers, sensorDataHandler, errorHandler),
-                (peripheral) => peripheral.uuid,
-            ),
-        )
-    } catch (e) {
-        errorHandler(e as Error)
-    }
+        .catch((e) => errorHandler(e as Error))
 }
 
 function handleDiscover(
     handlers: ThermometerHandler[],
     sensorDataHandler: (sensorData: SensorData) => void,
     errorHandler: (error: Error) => void,
-    noblePeripheral: Peripheral,
+    noblePeripheral: Noble.Peripheral,
 ) {
     const peripheral = {
         uuid: noblePeripheral.uuid,

--- a/src/adapters/ble/noble.ts
+++ b/src/adapters/ble/noble.ts
@@ -1,10 +1,10 @@
-import type _noble from '@abandonware/noble'
+import type NobleModule from '@abandonware/noble'
 import type { SensorData, ThermometerHandler } from '../../thermometer'
 import type { BlePeripheralsDiscovery } from './api'
 import { throttle } from '../../std'
 
-type Noble = typeof _noble
-type Peripheral = _noble.Peripheral
+type Noble = typeof NobleModule
+type Peripheral = NobleModule.Peripheral
 
 export const nobleDiscoverPeripherals: BlePeripheralsDiscovery = (
     handlers: ThermometerHandler[],

--- a/src/adapters/ble/noble.ts
+++ b/src/adapters/ble/noble.ts
@@ -6,10 +6,7 @@ import { throttle } from '../../std'
 function newNoble(module: {
     default: (new (args: Record<string, unknown>) => typeof Noble) | typeof Noble
 }): typeof Noble {
-    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-    // @ts-ignore Type information are foobar’ed
-    const noble = typeof module.default === 'function' ? new module.default({ extended: false }) : module.default
-    return noble
+    return typeof module.default === 'function' ? new module.default({ extended: false }) : module.default
 }
 
 export const nobleDiscoverPeripherals: BlePeripheralsDiscovery = (


### PR DESCRIPTION
Horribly enough, importing noble will fail on Linux if bluetooth is not supported. To work around that and have a chance to handle the exception gracefully, dynamically import noble but continue to import noble types eagerly. Using noble doesn’t get better but at least it’s all contained in a single module.