### PR TITLE
Prefix seems to be irrelevant when parsing temperature data

### DIFF
--- a/src/thermometer/brifit.ts
+++ b/src/thermometer/brifit.ts
@@ -75,7 +75,7 @@ export class BrifitParser implements Parser {
          * 14-15 | humidity
          * 16-19 | uptime: seconds since the last reset
          */
-        if (msg.length !== 20 || msg.readUInt8(0) !== 0x15) {
+        if (msg.length !== 20) {
             return null
         }
 

--- a/tests/thermometer/brifit.test.ts
+++ b/tests/thermometer/brifit.test.ts
@@ -79,12 +79,19 @@ describe('Test Brifit parser', () => {
         expect(brifitParser.parse(Buffer.from([]))).toBe(null)
     })
 
-    test('Parser will return null if unexpected first byte', () => {
-        expect(brifitParser.parse(Buffer.from(new Array(20)))).toBe(null)
-    })
-
     test('Parser will parse temperature, humidity and so on', () => {
         const msg = hexStrToBuffer('15 00 00 80 62 00 00 00 92 d6 ca 0b 4c 01 e4 02 64 f6 03 00')
+        expect(brifitParser.parse(msg)).toEqual({
+            buttonPressed: true,
+            batteryPercentage: 88.76470588235294,
+            humidityPercentage: 46.25,
+            temperatureCelsius: 20.75,
+            uptime: 259684,
+        })
+    })
+
+    test('Parser ignores prefix', () => {
+        const msg = hexStrToBuffer('18 00 00 80 62 00 00 00 92 d6 ca 0b 4c 01 e4 02 64 f6 03 00')
         expect(brifitParser.parse(msg)).toEqual({
             buttonPressed: true,
             batteryPercentage: 88.76470588235294,


### PR DESCRIPTION
According to https://github.com/lstrojny/homebridge-ble-thermobeacon/issues/29, the prefix does not seem to be stable so instead of checking for prefix and length, let’s only check for length.

Closes #29, #30